### PR TITLE
Go linted and less sensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # uri-utils-go
 Provides URI utils for public read apis such as:
 
-1. ApiURL - Establishing the ApiURL given a whether the Label is a Person, Organisation or Company (Public or Private)
-2. IdURL - Adds the appropriate prefix e.g http://api.ft.com/things/
-3. TypeURIs - Builds up the type URI based on type e.g http://www.ft.com/ontology/Person 
+1. APIURL - Establishing the ApiURL given a whether the Label is a Person, Organisation or Company (Public or Private)
+2. IDURL - Adds the appropriate prefix e.g http://api.ft.com/things/
+3. TypeURIs - Builds up the type URI based on type e.g http://www.ft.com/ontology/Person

--- a/mapper/uri_utils.go
+++ b/mapper/uri_utils.go
@@ -1,4 +1,4 @@
-package uriutils
+package mapper
 
 import (
 	"strings"

--- a/mapper/uri_utils_test.go
+++ b/mapper/uri_utils_test.go
@@ -1,4 +1,4 @@
-package uriutils
+package mapper
 
 import (
 	"github.com/stretchr/testify/assert"

--- a/uri_utils.go
+++ b/uri_utils.go
@@ -1,21 +1,25 @@
 package uriutils
 
-// ApiURL - Establishes the ApiURL given a whether the Label is a Person, Organisation or Company (Public or Private)
-func ApiURL(id string, types []string) string {
+import (
+	"strings"
+)
+
+// APIURL - Establishes the ApiURL given a whether the Label is a Person, Organisation or Company (Public or Private)
+func APIURL(id string, types []string) string {
 	base := "http://api.ft.com/"
 	for _, t := range types {
-		switch t {
-		case "Person":
+		switch strings.ToLower(t) {
+		case "person":
 			return base + "people/" + id
-		case "Organisation", "Company", "PublicCompany", "PrivateCompany":
+		case "organisation", "company", "publiccompany", "privatecompany":
 			return base + "organisations/" + id
 		}
 	}
 	return base + "things/" + id
 }
 
-// IdURL - Adds the appropriate prefix e.g http://api.ft.com/things/
-func IdURL(neoID string) string {
+// IDURL - Adds the appropriate prefix e.g http://api.ft.com/things/
+func IDURL(neoID string) string {
 	return "http://api.ft.com/things/" + neoID
 }
 
@@ -24,12 +28,12 @@ func TypeURIs(neoTypes []string) []string {
 	var results []string
 	base := "http://www.ft.com/ontology/"
 	for _, t := range neoTypes {
-		switch t {
-		case "Person":
+		switch strings.ToLower(t) {
+		case "person":
 			results = append(results, base+"person/Person")
-		case "Organisation":
+		case "organisation":
 			results = append(results, base+"organisation/"+t)
-		case "Company", "PublicCompany", "PrivateCompany":
+		case "company", "publiccompany", "privatecompany":
 			results = append(results, base+"company/"+t)
 		}
 	}

--- a/uri_utils.go
+++ b/uri_utils.go
@@ -5,36 +5,40 @@ import (
 )
 
 // APIURL - Establishes the ApiURL given a whether the Label is a Person, Organisation or Company (Public or Private)
-func APIURL(id string, types []string) string {
+func APIURL(uuid string, labels []string) string {
 	base := "http://api.ft.com/"
-	for _, t := range types {
-		switch strings.ToLower(t) {
+	for _, label := range labels {
+		switch strings.ToLower(label) {
 		case "person":
-			return base + "people/" + id
+			return base + "people/" + uuid
 		case "organisation", "company", "publiccompany", "privatecompany":
-			return base + "organisations/" + id
+			return base + "organisations/" + uuid
 		}
 	}
-	return base + "things/" + id
+	return base + "things/" + uuid
 }
 
 // IDURL - Adds the appropriate prefix e.g http://api.ft.com/things/
-func IDURL(neoID string) string {
-	return "http://api.ft.com/things/" + neoID
+func IDURL(uuid string) string {
+	return "http://api.ft.com/things/" + uuid
 }
 
 // TypeURIs - Builds up the type URI based on type e.g http://www.ft.com/ontology/Person
-func TypeURIs(neoTypes []string) []string {
+func TypeURIs(labels []string) []string {
 	var results []string
 	base := "http://www.ft.com/ontology/"
-	for _, t := range neoTypes {
-		switch strings.ToLower(t) {
+	for _, label := range labels {
+		switch strings.ToLower(label) {
 		case "person":
 			results = append(results, base+"person/Person")
 		case "organisation":
-			results = append(results, base+"organisation/"+t)
-		case "company", "publiccompany", "privatecompany":
-			results = append(results, base+"company/"+t)
+			results = append(results, base+"organisation/Organisation")
+		case "company":
+			results = append(results, base+"company/Company")
+		case "publiccompany":
+			results = append(results, base+"company/PublicCompany")
+		case "privatecompany":
+			results = append(results, base+"company/PrivateCompany")
 		}
 	}
 	return results

--- a/uri_utils_test.go
+++ b/uri_utils_test.go
@@ -1,9 +1,8 @@
 package uriutils
 
 import (
-	"testing"
-
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestTypeURIsForPeople(t *testing.T) {
@@ -44,4 +43,29 @@ func TestTypeURIsForPrivateCompany(t *testing.T) {
 		"http://www.ft.com/ontology/company/Company"}
 	actualURIs := TypeURIs(typesFromNeo)
 	assert.New(t).EqualValues(expectedURIs, actualURIs)
+}
+
+func TestCompanyAPIURLs(t *testing.T) {
+	apiSpecificNeoTypes := []string{"PublicCompany", "PrivateCompany", "Organisation", "Company",
+		"publiccompany", "PRIVATECompany"}
+	expectedAPIURLRegex := "http://api.ft.com/organisations/[w-]*"
+	for _, neoType := range apiSpecificNeoTypes {
+		assert.New(t).Regexp(expectedAPIURLRegex, APIURL("92f4ec09-436d-4092-a88c-96f54e34007c", []string{neoType}))
+	}
+}
+
+func TestPeopleAPIURLs(t *testing.T) {
+	apiSpecificNeoTypes := []string{"Person", "person"}
+	expectedAPIURLRegex := "http://api.ft.com/people/[w-]*"
+	for _, neoType := range apiSpecificNeoTypes {
+		assert.New(t).Regexp(expectedAPIURLRegex, APIURL("92f4ec09-436d-4092-a88c-96f54e34007c", []string{neoType}))
+	}
+}
+
+func TestDefaultAPIURLs(t *testing.T) {
+	apiSpecificNeoTypes := []string{"thing", "relationship", "otherPrivateType"}
+	expectedAPIURLRegex := "http://api.ft.com/things/[w-]*"
+	for _, neoType := range apiSpecificNeoTypes {
+		assert.New(t).Regexp(expectedAPIURLRegex, APIURL("92f4ec09-436d-4092-a88c-96f54e34007c", []string{neoType}))
+	}
 }

--- a/uri_utils_test.go
+++ b/uri_utils_test.go
@@ -3,69 +3,113 @@ package uriutils
 import (
 	"github.com/stretchr/testify/assert"
 	"testing"
+	"unicode"
 )
 
+var thingLabels = []string{"Thing"}
+var conceptLabels = append(thingLabels, "Concept")
+var personLabels = append(conceptLabels, "Person")
+var organisationLabels = append(conceptLabels, "Organisation")
+var companyLabels = append(organisationLabels, "Company")
+var publicCompanyLabels = append(companyLabels, "PublicCompany")
+var privateCompanyLabels = append(companyLabels, "PrivateCompany")
+
+var personURIs = []string{"http://www.ft.com/ontology/person/Person"}
+var organisationURIs = []string{"http://www.ft.com/ontology/organisation/Organisation"}
+var companyURIs = append(organisationURIs, "http://www.ft.com/ontology/company/Company")
+var publicCompanyURIs = append(companyURIs, "http://www.ft.com/ontology/company/PublicCompany")
+var privateCompanyURIs = append(companyURIs, "http://www.ft.com/ontology/company/PrivateCompany")
+
+var baseAPIURL = "http://api.ft.com/"
+var thingAPIURLRegex = baseAPIURL + "things/[w-]*"
+var personAPIURLRegex = baseAPIURL + "people/[w-]*"
+var organisationAPIURLRegex = baseAPIURL + "organisations/[w-]*"
+
 func TestTypeURIsForPeople(t *testing.T) {
-	typesFromNeo := []string{"Person", "Concept", "Thing"}
-	expectedURIs := []string{"http://www.ft.com/ontology/person/Person"}
-	actualURIs := TypeURIs(typesFromNeo)
-	assert.New(t).EqualValues(expectedURIs, actualURIs)
+	assert.New(t).EqualValues(personURIs, TypeURIs(personLabels))
 }
 
 func TestTypeURIsForOrganisations(t *testing.T) {
-	typesFromNeo := []string{"Organisation", "Concept", "Thing"}
-	expectedURIs := []string{"http://www.ft.com/ontology/organisation/Organisation"}
-	actualURIs := TypeURIs(typesFromNeo)
-	assert.New(t).EqualValues(expectedURIs, actualURIs)
+	assert.New(t).EqualValues(organisationURIs, TypeURIs(organisationLabels))
 }
 
 func TestTypeURIsForCompany(t *testing.T) {
-	typesFromNeo := []string{"Organisation", "Company", "Concept", "Thing"}
-	expectedURIs := []string{"http://www.ft.com/ontology/organisation/Organisation",
-		"http://www.ft.com/ontology/company/Company"}
-	actualURIs := TypeURIs(typesFromNeo)
-	assert.New(t).EqualValues(expectedURIs, actualURIs)
+	assert.New(t).EqualValues(companyURIs, TypeURIs(companyLabels))
 }
 
 func TestTypeURIsForPublicCompany(t *testing.T) {
-	typesFromNeo := []string{"PublicCompany", "Organisation", "Company", "Concept", "Thing"}
-	expectedURIs := []string{"http://www.ft.com/ontology/company/PublicCompany",
-		"http://www.ft.com/ontology/organisation/Organisation",
-		"http://www.ft.com/ontology/company/Company"}
-	actualURIs := TypeURIs(typesFromNeo)
-	assert.New(t).EqualValues(expectedURIs, actualURIs)
+	assert.New(t).EqualValues(publicCompanyURIs, TypeURIs(publicCompanyLabels))
 }
 
 func TestTypeURIsForPrivateCompany(t *testing.T) {
-	typesFromNeo := []string{"PrivateCompany", "Organisation", "Company", "Concept", "Thing"}
-	expectedURIs := []string{"http://www.ft.com/ontology/company/PrivateCompany",
-		"http://www.ft.com/ontology/organisation/Organisation",
-		"http://www.ft.com/ontology/company/Company"}
-	actualURIs := TypeURIs(typesFromNeo)
-	assert.New(t).EqualValues(expectedURIs, actualURIs)
+	assert.New(t).EqualValues(privateCompanyURIs, TypeURIs(privateCompanyLabels))
 }
 
 func TestCompanyAPIURLs(t *testing.T) {
-	apiSpecificNeoTypes := []string{"PublicCompany", "PrivateCompany", "Organisation", "Company",
+	neoLabels := []string{"PublicCompany", "PrivateCompany", "Organisation", "Company",
 		"publiccompany", "PRIVATECompany"}
-	expectedAPIURLRegex := "http://api.ft.com/organisations/[w-]*"
-	for _, neoType := range apiSpecificNeoTypes {
-		assert.New(t).Regexp(expectedAPIURLRegex, APIURL("92f4ec09-436d-4092-a88c-96f54e34007c", []string{neoType}))
+	for _, neoLabel := range neoLabels {
+		assert.New(t).Regexp(organisationAPIURLRegex, APIURL("92f4ec09-436d-4092-a88c-96f54e34007c", []string{neoLabel}))
 	}
 }
 
 func TestPeopleAPIURLs(t *testing.T) {
-	apiSpecificNeoTypes := []string{"Person", "person"}
-	expectedAPIURLRegex := "http://api.ft.com/people/[w-]*"
-	for _, neoType := range apiSpecificNeoTypes {
-		assert.New(t).Regexp(expectedAPIURLRegex, APIURL("92f4ec09-436d-4092-a88c-96f54e34007c", []string{neoType}))
+	neoLabels := []string{"Person", "person"}
+	for _, neoLabel := range neoLabels {
+		assert.New(t).Regexp(personAPIURLRegex, APIURL("92f4ec09-436d-4092-a88c-96f54e34007c", []string{neoLabel}))
 	}
 }
 
 func TestDefaultAPIURLs(t *testing.T) {
-	apiSpecificNeoTypes := []string{"thing", "relationship", "otherPrivateType"}
-	expectedAPIURLRegex := "http://api.ft.com/things/[w-]*"
-	for _, neoType := range apiSpecificNeoTypes {
-		assert.New(t).Regexp(expectedAPIURLRegex, APIURL("92f4ec09-436d-4092-a88c-96f54e34007c", []string{neoType}))
+	neoLabels := []string{"thing", "relationship", "otherPrivateType"}
+	for _, neoLabel := range neoLabels {
+		assert.New(t).Regexp(thingAPIURLRegex, APIURL("92f4ec09-436d-4092-a88c-96f54e34007c", []string{neoLabel}))
 	}
+}
+
+func TestInsensitivePersonTypeURIs(t *testing.T) {
+	neoLabels := caseMixer(personLabels)
+	assert.New(t).EqualValues(personURIs, TypeURIs(neoLabels))
+}
+
+func TestInsensitiveOrganisationTypeURIs(t *testing.T) {
+	neoLabels := caseMixer(organisationLabels)
+	assert.New(t).EqualValues(organisationURIs, TypeURIs(neoLabels))
+}
+
+func TestInsensitiveCompanyTypeURIs(t *testing.T) {
+	neoLabels := caseMixer(companyLabels)
+	assert.New(t).EqualValues(companyURIs, TypeURIs(neoLabels))
+}
+
+func TestInsensitivePublicCompanyTypeURIs(t *testing.T) {
+	neoLabels := caseMixer(publicCompanyLabels)
+	assert.New(t).EqualValues(publicCompanyURIs, TypeURIs(neoLabels))
+}
+
+func TestInsensitivePrivateCompanyTypeURIs(t *testing.T) {
+	neoLabels := caseMixer(privateCompanyLabels)
+	assert.New(t).EqualValues(privateCompanyURIs, TypeURIs(neoLabels))
+}
+
+func caseMixer(toMixUp []string) (mixedUp []string) {
+	mixedUp = toMixUp
+	for idx := range mixedUp {
+		mixedUp[idx] = mixUpCase(mixedUp[idx])
+	}
+	return mixedUp
+}
+
+func mixUpCase(toMixUp string) (mixedUp string) {
+	for idx, rune := range toMixUp {
+		if idx%2 == 0 {
+			if unicode.IsUpper(rune) {
+				rune = unicode.ToLower(rune)
+			} else {
+				rune = unicode.ToUpper(rune)
+			}
+		}
+		mixedUp += string(rune)
+	}
+	return mixedUp
 }


### PR DESCRIPTION
The current implementation fails golint, unless we have good reason I don't think we should make up alternative lints.
At the same time this will break existing code, so up for debate.
The patch also makes type matching case insensitive, which would seem a reasonably good idea. I've added some test cases for APIURL, which were missing